### PR TITLE
improvements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,9 @@
 FFcuesplitter-GUI
-Splits the audio CD images supplied with the CUE sheet via FFmpeg. 
+Splits the audio CD images supplied with the CUE sheet via FFmpeg.
 
 Author:
 Gianluca (jeanslack) Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023
 
 Translators:
 Gianluca Pernigotto <jeanlucperni@gmail.com> (Italian)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,13 +10,16 @@ Change Log:
 Thu, 10 Aug 2023 V.1.0.5 (unreleased)
 
 - Removed `wx.lib.mixins.listctrl` (with checkbox functionality)
-- Fixed code to new FFcuesplitter API v1.0.21.
+- Fixed code to new FFcuesplitter API v1.0.22.
 - Added opus format/codec
 - Fixed: `FFcuesplitter-GUI/ffcuesplitter_gui/_panels/cuesplitter_panel.py:400:
           DeprecationWarning: an integer is required (got type float).  Implicit
           conversion to integers using __int__ is deprecated, and may be removed
           in a future version of Python.
   self.barprog.SetValue(percent)`
+- Make output directory if doesn't exists (or if it was deleted)
+- Fixed output format issue.
+- Code factorized.
 
 +------------------------------------+
 Dec 14, 2022 V.1.0.2 (unreleased)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,10 +7,10 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Jan 29, 2023 V.1.0.5 (unreleased)
+Feb 04, 2023 V.1.0.5 (unreleased)
 
 - Removed `wx.lib.mixins.listctrl` (with checkbox functionality)
-- Fixed code to new FFcuesplitter API.
+- Fixed code to new FFcuesplitter API v1.0.21.
 - Added opus format/codec
 
 +------------------------------------+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,11 +7,16 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
-Feb 04, 2023 V.1.0.5 (unreleased)
+Thu, 10 Aug 2023 V.1.0.5 (unreleased)
 
 - Removed `wx.lib.mixins.listctrl` (with checkbox functionality)
 - Fixed code to new FFcuesplitter API v1.0.21.
 - Added opus format/codec
+- Fixed: `FFcuesplitter-GUI/ffcuesplitter_gui/_panels/cuesplitter_panel.py:400:
+          DeprecationWarning: an integer is required (got type float).  Implicit
+          conversion to integers using __int__ is deprecated, and may be removed
+          in a future version of Python.
+  self.barprog.SetValue(percent)`
 
 +------------------------------------+
 Dec 14, 2022 V.1.0.2 (unreleased)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,13 @@ License: GPL3
 Change Log:
 
 +------------------------------------+
+Jan 29, 2023 V.1.0.5 (unreleased)
+
+- Removed `wx.lib.mixins.listctrl` (with checkbox functionality)
+- Fixed code to new FFcuesplitter API.
+- Added opus format/codec
+
++------------------------------------+
 Dec 14, 2022 V.1.0.2 (unreleased)
 
 - Fixed `FileNotFoundError` exception if the log directory does not yet exist.

--- a/TODO
+++ b/TODO
@@ -13,3 +13,8 @@
 - Check MANIFEST.in.
 - Make debian dir.
 - Write INSTALL basic for installations.
+
+BUG verifieds
+- Auto-make output folder if it doesn't exist.
+- The codec/output format is always flac even if you choose another format
+  among those available (wav, opus, mp3, ogg)

--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
 
 
-
+- check code with a linter (flake8/pylint)
 - Make io.github.jeanslack.ffcuesplitter-gui.desktop.
 - Make ffcuesplitter-gui.icns.
 - make ffcuesplitter-gui.ico

--- a/ffcuesplitter_gui/_dialogs/cd_info.py
+++ b/ffcuesplitter_gui/_dialogs/cd_info.py
@@ -4,7 +4,7 @@ Name: cd_info.py
 Porpose: view CD audio info and other informations
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.08.2022
 Code checher: flake8, pylint

--- a/ffcuesplitter_gui/_dialogs/check_new_version.py
+++ b/ffcuesplitter_gui/_dialogs/check_new_version.py
@@ -4,7 +4,7 @@ Name: check_new_version.py
 Porpose: shows informative messages on version in use and new releases
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2018/2021 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Sept.28.2021
 Code checker: pycodestyle / flake8 --ignore=F821,W503

--- a/ffcuesplitter_gui/_dialogs/check_new_version.py
+++ b/ffcuesplitter_gui/_dialogs/check_new_version.py
@@ -115,9 +115,8 @@ class CheckNewVersion(wx.Dialog):
         Go to the specific download page for your platform
         """
         if CheckNewVersion.OS in ('Linux', 'Darwin', 'Windows'):
-
-           page = ('https://github.com/jeanslack/FFcuesplitter-GUI'
-                   '/releases/latest/')
+            page = ('https://github.com/jeanslack/FFcuesplitter-GUI'
+                    '/releases/latest/')
 
         webbrowser.open(page)
     # ------------------------------------------------------------------#

--- a/ffcuesplitter_gui/_dialogs/infoprg.py
+++ b/ffcuesplitter_gui/_dialogs/infoprg.py
@@ -4,7 +4,7 @@ Name: infoprog.py
 Porpose: about ffcuesplitter-gui
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.08.2022
 ########################################################

--- a/ffcuesplitter_gui/_dialogs/preferences.py
+++ b/ffcuesplitter_gui/_dialogs/preferences.py
@@ -4,7 +4,7 @@ Name: preferences.py
 Porpose: FFcuesplitter-GUI setup dialog
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Jan.30.2022
 Code checker: flake8, pylint

--- a/ffcuesplitter_gui/_dialogs/showlogs.py
+++ b/ffcuesplitter_gui/_dialogs/showlogs.py
@@ -4,7 +4,7 @@ Name: showlogs.py
 Porpose: show logs data
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker flake8, pylint

--- a/ffcuesplitter_gui/_dialogs/track_info.py
+++ b/ffcuesplitter_gui/_dialogs/track_info.py
@@ -4,7 +4,7 @@ Name: track_info.py
 Porpose: view and edit selected track metadata
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.08.2022
 Code checher: flake8, pylint

--- a/ffcuesplitter_gui/_dialogs/widget_utils.py
+++ b/ffcuesplitter_gui/_dialogs/widget_utils.py
@@ -4,7 +4,7 @@ Name: widget_utils.py
 Porpose: Features a set of useful wx widgets to use dynamically
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker: flake8, pylint

--- a/ffcuesplitter_gui/_dialogs/wizard_dlg.py
+++ b/ffcuesplitter_gui/_dialogs/wizard_dlg.py
@@ -4,7 +4,7 @@ Name: wizard_dlg.py
 Porpose: wizard setup dialog
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker: flake8, pylint

--- a/ffcuesplitter_gui/_io/io_tools.py
+++ b/ffcuesplitter_gui/_io/io_tools.py
@@ -4,7 +4,7 @@ Name: io_tools.py
 Porpose: input/output redirection to some processes
 Compatibility: Python3, wxPython4 Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.03.2022
 Code checker: flake8, pylint

--- a/ffcuesplitter_gui/_main/main_frame.py
+++ b/ffcuesplitter_gui/_main/main_frame.py
@@ -4,7 +4,7 @@ Name: main_frame.py
 Porpose: top window main frame
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker: flake8, pylint
@@ -533,7 +533,7 @@ class MainFrame(wx.Frame):
         """
         Call track info dialog
         """
-        index = self.gui_panel.tlist.GetFocusedItem()
+        index = self.gui_panel.tracklist.GetFocusedItem()
         with TrackInfo(self,
                        self.gui_panel.data.audiotracks,
                        index

--- a/ffcuesplitter_gui/_main/main_frame.py
+++ b/ffcuesplitter_gui/_main/main_frame.py
@@ -388,27 +388,27 @@ class MainFrame(wx.Frame):
         """
         if self.appdata['toolbarpos'] == 0:  # on top
             if self.appdata['toolbartext'] is True:  # show text
-                style = (wx.TB_TEXT | wx.TB_HORZ_LAYOUT | wx.TB_HORIZONTAL)
+                style = wx.TB_TEXT | wx.TB_HORZ_LAYOUT | wx.TB_HORIZONTAL
             else:
-                style = (wx.TB_DEFAULT_STYLE)
+                style = wx.TB_DEFAULT_STYLE
 
         elif self.appdata['toolbarpos'] == 1:  # on bottom
             if self.appdata['toolbartext'] is True:  # show text
-                style = (wx.TB_TEXT | wx.TB_HORZ_LAYOUT | wx.TB_BOTTOM)
+                style = wx.TB_TEXT | wx.TB_HORZ_LAYOUT | wx.TB_BOTTOM
             else:
-                style = (wx.TB_DEFAULT_STYLE | wx.TB_BOTTOM)
+                style = wx.TB_DEFAULT_STYLE | wx.TB_BOTTOM
 
         elif self.appdata['toolbarpos'] == 2:  # on right
             if self.appdata['toolbartext'] is True:  # show text
-                style = (wx.TB_TEXT | wx.TB_RIGHT)
+                style = wx.TB_TEXT | wx.TB_RIGHT
             else:
-                style = (wx.TB_DEFAULT_STYLE | wx.TB_RIGHT)
+                style = wx.TB_DEFAULT_STYLE | wx.TB_RIGHT
 
         elif self.appdata['toolbarpos'] == 3:
             if self.appdata['toolbartext'] is True:  # show text
-                style = (wx.TB_TEXT | wx.TB_LEFT)
+                style = wx.TB_TEXT | wx.TB_LEFT
             else:
-                style = (wx.TB_DEFAULT_STYLE | wx.TB_LEFT)
+                style = wx.TB_DEFAULT_STYLE | wx.TB_LEFT
 
         self.toolbar = self.CreateToolBar(style=style)
 

--- a/ffcuesplitter_gui/_panels/cuesplitter_panel.py
+++ b/ffcuesplitter_gui/_panels/cuesplitter_panel.py
@@ -32,7 +32,7 @@ import datetime
 import wx
 import wx.lib.scrolledpanel as scrolled
 from pubsub import pub
-from ffcuesplitter.cuesplitter import FFCueSplitter
+from ffcuesplitter.cuesplitter import FFCueSplitter, DataArgs
 from ffcuesplitter_gui._utils.utils import get_codec_quality_items
 from ffcuesplitter_gui._threads.ffmpeg_processing import Processing
 from ffcuesplitter_gui._dialogs.widget_utils import notification_area
@@ -213,14 +213,14 @@ class CueGui(wx.Panel):
         """
         self.txt_path_cue.SetValue(newincoming)
 
-        self.data = FFCueSplitter(newincoming,
-                                  ffprobe_cmd=self.appdata['ffprobe_cmd'],
-                                  ffmpeg_cmd=self.appdata['ffmpeg_cmd'],
-                                  ffmpeg_loglevel=self.appdata['ffmpegloglev'],
-                                  progress_meter='tqdm',
-                                  )  # instance
+        argsdata = DataArgs(newincoming,
+                            ffprobe_cmd=self.appdata['ffprobe_cmd'],
+                            ffmpeg_cmd=self.appdata['ffmpeg_cmd'],
+                            ffmpeg_loglevel=self.appdata['ffmpegloglev'],
+                            progress_meter='tqdm',
+                            )  # instance
         try:
-            self.data.open_cuefile()
+            self.data = FFCueSplitter(**argsdata.asdict())
         except Exception as err:
             wx.MessageBox(f'{err}', "ERROR", wx.ICON_ERROR, self)
             return
@@ -358,7 +358,7 @@ class CueGui(wx.Panel):
                                        prefix='FFcuesplitterGUI_',
                                        dir=None)
         self.update_attributes_of_ffcuesplitter_api(self.tmpdir)  # set all
-        args = self.data.commandargs()  # get command/arguments list
+        args = self.data.commandargs(self.data.audiotracks)
 
         self.parent.toolbar.EnableTool(13, True)  # stop
         self.parent.toolbar.EnableTool(12, False)  # start

--- a/ffcuesplitter_gui/_panels/cuesplitter_panel.py
+++ b/ffcuesplitter_gui/_panels/cuesplitter_panel.py
@@ -397,7 +397,7 @@ class CueGui(wx.Panel):
         percent = secs / round(duration) * 100
         msg = _("Processing... File number: {} | Status "
                 "Progress: {}%").format(track, round(percent))
-        self.barprog.SetValue(percent)
+        self.barprog.SetValue(round(percent))
         self.parent.statusbar_msg(msg, bgrd='BLACK', fgrd='GREEN YELLOW')
     # ----------------------------------------------------------------------
 

--- a/ffcuesplitter_gui/_sys/argparser.py
+++ b/ffcuesplitter_gui/_sys/argparser.py
@@ -4,7 +4,7 @@ Name: argparser.py
 Porpose: FFcuesplitter-GUI Command line arguments
 Compatibility: Python3
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2021/2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker: flake8, pylint .

--- a/ffcuesplitter_gui/_sys/info.py
+++ b/ffcuesplitter_gui/_sys/info.py
@@ -4,7 +4,7 @@ Name: info.py
 Porpose: holds package information
 Compatibility: Python3
 author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-copyr: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 lic: GPL3
 Rev: Jan.31.2022
 Code checker: flake8, pylint
@@ -25,7 +25,7 @@ This file is part of FFcuesplitter-GUI.
    You should have received a copy of the GNU General Public License
    along with FFcuesplitter-GUI.  If not, see <http://www.gnu.org/licenses/>.
 """
-__version__ = "1.0.2"
+__version__ = "1.0.5"
 __author__ = "Gianluca Pernigotto"
 __contact__ = "jeanlucperni@gmail.com"
 __maintainer__ = "Gianluca Pernigotto (jeanslack)"
@@ -43,7 +43,7 @@ checkboxes to select track extractions, an audio CD properties viewer, support
 for WAV, FLAC, MP3 and OGG output formats, audio compression selectors and the
 ability to copy audio codec without re-encoding.
 """
-__copyleft__ = '2022'
+__copyleft__ = '2023'
 __licensefull__ = f"""
 copyleft - {__copyleft__} {__author__}
 Author and Developer: {__author__}

--- a/ffcuesplitter_gui/_sys/settings_manager.py
+++ b/ffcuesplitter_gui/_sys/settings_manager.py
@@ -4,7 +4,7 @@ Name: settings_manager.py
 Porpose: Set FFcuesplitter-gui configuration on startup
 Compatibility: Python3
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.07.2022
 Code checker: flake8, pylint .

--- a/ffcuesplitter_gui/_threads/ffmpeg_processing.py
+++ b/ffcuesplitter_gui/_threads/ffmpeg_processing.py
@@ -26,7 +26,6 @@ This file is part of FFcuesplitter-GUI.
 """
 from threading import Thread
 import time
-import itertools
 import subprocess
 import platform
 from ffcuesplitter.utils import Popen

--- a/ffcuesplitter_gui/_threads/opendir.py
+++ b/ffcuesplitter_gui/_threads/opendir.py
@@ -32,6 +32,21 @@ def browse(opsyst, pathname):
     """
     open file browser in a specific location (OS independent)
 
+    NOTE The following code work, but on MS-Windows it show a short of
+    Dos-window
+    -----------------
+
+    try:
+        p = subprocess.run(cmd)
+        if p.stderr:
+            return(p.stderr.decode())
+            '''
+            if not *capture_output=True* on subprocess instance
+            use .decode() here.
+            '''
+    except FileNotFoundError as err:
+        return('%s' % (err))
+
     """
     status = 'Unrecognized error'
 
@@ -72,20 +87,3 @@ def browse(opsyst, pathname):
         status = f'{oserr}'
 
     return status
-
-    """
-    NOTE The following code work, but on MS-Windows it show a short of
-         Dos-window
-    -----------------
-
-    try:
-        p = subprocess.run(cmd)
-        if p.stderr:
-            return(p.stderr.decode())
-            '''
-            if not *capture_output=True* on subprocess instance
-            use .decode() here.
-            '''
-    except FileNotFoundError as err:
-        return('%s' % (err))
-    """

--- a/ffcuesplitter_gui/_threads/opendir.py
+++ b/ffcuesplitter_gui/_threads/opendir.py
@@ -4,7 +4,7 @@ Name: opendir.py
 Porpose: open file browser on given pathname
 Compatibility: Python3 (Unix, Windows)
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker: flake8, pylint

--- a/ffcuesplitter_gui/_utils/get_bmpfromsvg.py
+++ b/ffcuesplitter_gui/_utils/get_bmpfromsvg.py
@@ -4,7 +4,7 @@ Name: get_bmpfromSvg.py
 Porpose: return bmp image from a scalable vector graphic format (svg)
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Jan.31.2022
 ########################################################

--- a/ffcuesplitter_gui/_utils/utils.py
+++ b/ffcuesplitter_gui/_utils/utils.py
@@ -4,7 +4,7 @@ Name: utils.py
 Porpose: It groups useful functions that are called several times
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.03.2022
 Code checker: flake8, pylint .
@@ -99,6 +99,20 @@ def get_codec_quality_items(_format_):
                      "VBR 260 kbit/s": "-aq 8",
                      "VBR 320 kbit/s": "-aq 9",
                      "very good quality": "-aq 10"
+                         },
+                 'opus':
+                     {"Auto": "",
+                     "low quality 0": "-compression_level 0",
+                     "low quality 1": "-compression_level 1",
+                     "quality 2": "-compression_level 2",
+                     "quality 3": "-compression_level 3",
+                     "quality 4": "-compression_level 4",
+                     "medium quality 5": "-compression_level 5",
+                     "quality 6": "-compression_level 6",
+                     "quality 7": "-compression_level 7",
+                     "quality 8": "-compression_level 8",
+                     "high quality 9": "-compression_level 9",
+                     "highest quality 10 (default)": "-compression_level 10",
                          },
                  'mp3':
                      {"Auto": "",

--- a/ffcuesplitter_gui/_utils/utils.py
+++ b/ffcuesplitter_gui/_utils/utils.py
@@ -73,55 +73,52 @@ def get_codec_quality_items(_format_):
     Given an audio format, it returns the corresponding
     audio compression references,if available.
     """
-    qualities = {'wav':
-                     {"Auto": ""},
-                 'flac':
-                     {"Auto": "",
-                      "very high quality": "-compression_level 0",
-                      "quality 1": "-compression_level 1" ,
-                      "quality 2": "-compression_level 2",
-                      "quality 3": "-compression_level 3",
-                      "quality 4": "-compression_level 4",
-                      "Standard quality": "-compression_level 5",
-                      "quality 6": "-compression_level 6",
-                      "quality 7": "-compression_level 7",
-                      "low quality": "-compression_level 8"
+    qualities = {'wav': {"Auto": ""},
+                 'flac': {"Auto": "",
+                          "very high quality": "-compression_level 0",
+                          "quality 1": "-compression_level 1",
+                          "quality 2": "-compression_level 2",
+                          "quality 3": "-compression_level 3",
+                          "quality 4": "-compression_level 4",
+                          "Standard quality": "-compression_level 5",
+                          "quality 6": "-compression_level 6",
+                          "quality 7": "-compression_level 7",
+                          "low quality": "-compression_level 8"
                           },
-                 'ogg':
-                     {"Auto": "",
-                     "very poor quality": "-aq 1",
-                     "VBR 92 kbit/s": "-aq 2",
-                     "VBR 128 kbit/s": "-aq 3",
-                     "VBR 160 kbit/s": "-aq 4",
-                     "VBR 175 kbit/s": "-aq 5",
-                     "VBR 192 kbit/s": "-aq 6",
-                     "VBR 220 kbit/s": "-aq 7",
-                     "VBR 260 kbit/s": "-aq 8",
-                     "VBR 320 kbit/s": "-aq 9",
-                     "very good quality": "-aq 10"
+                 'ogg': {"Auto": "",
+                         "very poor quality": "-aq 1",
+                         "VBR 92 kbit/s": "-aq 2",
+                         "VBR 128 kbit/s": "-aq 3",
+                         "VBR 160 kbit/s": "-aq 4",
+                         "VBR 175 kbit/s": "-aq 5",
+                         "VBR 192 kbit/s": "-aq 6",
+                         "VBR 220 kbit/s": "-aq 7",
+                         "VBR 260 kbit/s": "-aq 8",
+                         "VBR 320 kbit/s": "-aq 9",
+                         "very good quality": "-aq 10"
                          },
-                 'opus':
-                     {"Auto": "",
-                     "low quality 0": "-compression_level 0",
-                     "low quality 1": "-compression_level 1",
-                     "quality 2": "-compression_level 2",
-                     "quality 3": "-compression_level 3",
-                     "quality 4": "-compression_level 4",
-                     "medium quality 5": "-compression_level 5",
-                     "quality 6": "-compression_level 6",
-                     "quality 7": "-compression_level 7",
-                     "quality 8": "-compression_level 8",
-                     "high quality 9": "-compression_level 9",
-                     "highest quality 10 (default)": "-compression_level 10",
-                         },
-                 'mp3':
-                     {"Auto": "",
-                     "VBR 128 kbit/s (low quality)": "-b:a 128k",
-                     "VBR 160 kbit/s": "-b:a 160k",
-                     "VBR 192 kbit/s": "-b:a 192k",
-                     "VBR 260 kbit/s": "-b:a 260k",
-                     "CBR 320 kbit/s (very good quality)": "-b:a 320k"
-                         }}
+                 'opus': {"Auto": "",
+                          "low quality 0": "-compression_level 0",
+                          "low quality 1": "-compression_level 1",
+                          "quality 2": "-compression_level 2",
+                          "quality 3": "-compression_level 3",
+                          "quality 4": "-compression_level 4",
+                          "medium quality 5": "-compression_level 5",
+                          "quality 6": "-compression_level 6",
+                          "quality 7": "-compression_level 7",
+                          "quality 8": "-compression_level 8",
+                          "high quality 9": "-compression_level 9",
+                          "highest quality 10 (default)":
+                          "-compression_level 10",
+                          },
+                 'mp3': {"Auto": "",
+                         "VBR 128 kbit/s (low quality)": "-b:a 128k",
+                         "VBR 160 kbit/s": "-b:a 160k",
+                         "VBR 192 kbit/s": "-b:a 192k",
+                         "VBR 260 kbit/s": "-b:a 260k",
+                         "CBR 320 kbit/s (very good quality)": "-b:a 320k"
+                         }
+                 }
     return qualities[_format_]
 # ------------------------------------------------------------------------
 

--- a/ffcuesplitter_gui/gui_app.py
+++ b/ffcuesplitter_gui/gui_app.py
@@ -4,7 +4,7 @@ Name: gui_app.py
 Porpose: bootstrap for FFcuesplitter-GUI app.
 Compatibility: Python3, wxPython Phoenix
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022/2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.04.2022
 Code checker: flake8, pylint

--- a/launcher
+++ b/launcher
@@ -5,7 +5,7 @@ Name: launcher.py
 Porpose: main launch script of ffcuesplitter_gui
 Compatibility: Python3
 Author: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Jan.26.2022
 Code checker: flake8, pylint

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Porpose: script to setup FFcuesplitter-gui.
 Compatibility: Python3
 Platform: all
 Writer: Gianluca Pernigotto <jeanlucperni@gmail.com>
-Copyright: (c) 2022-2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
+Copyright: 2023-2023 Gianluca Pernigotto <jeanlucperni@gmail.com>
 license: GPL3
 Rev: Feb.09.2022
 Code checker: flake8, pylint


### PR DESCRIPTION
This PR:

- Removes `wx.lib.mixins.listctrl` (with checkbox functionality)
- Fixes code to new FFcuesplitter API v.1.0.20.
- Adds opus format/codec.
- Fixes `FFcuesplitter-GUI/ffcuesplitter_gui/_panels/cuesplitter_panel.py:400: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.` error on `self.barprog.SetValue(percent)`
- Fixes `[Errno 2] File or directory does not exist` error, auto-creating the output directory if it does not exist (or if it has been deleted).
- Fixes output format issue.
- Code factorized.