### PR TITLE
Bug Fixes for Windows installations

### DIFF
--- a/ffcuesplitter_gui/_threads/ffmpeg_processing.py
+++ b/ffcuesplitter_gui/_threads/ffmpeg_processing.py
@@ -88,7 +88,9 @@ class Processing(Thread):
                          msg='',
                          end='',
                          )
-            if not platform.system() == 'Windows':
+            if platform.system() == 'Windows':
+                cmdargs = recipes[0]
+            else:
                 cmdargs = shlex.split(recipes[0])
 
             with open(self.logname, "w", encoding='utf-8') as log:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyPubSub>=4.0.3
 ffcuesplitter>=1.0.22
 
-[:platform_system == "Windows" or platform_system == "Darwin"]
-wxpython>=4.0.7 
+wxpython>=4.0.7; platform_system == "Windows" or platform_system == "Darwin"
+requests>=2.32.3; platform_system == "Windows" or platform_system == "Darwin"


### PR DESCRIPTION
## Fix two bugs affecting Windows installations

1. [Critical] `UnboundLocalError` prevents program execution on Windows
2. [Medium] `pip install -r requirements.txt` fails on Windows due to conditional declaration; module `requests` is required but undeclared

### Bug 1
#### Steps to Reproduce
After successfully installing requirements, running `python launcher` on Windows results in the following error:
```
>python launcher
Info: frozen=False meipass=False launcher=True
Exception in thread Thread-3:
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.13_3.13.1008.0_x64__qbz5n2kfra8p0\Lib\threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "FFcuesplitter-GUI\ffcuesplitter_gui\_threads\ffmpeg_processing.py", line 95, in run
    log.write(f'\nCOMMAND: {cmdargs}')
                            ^^^^^^^
UnboundLocalError: cannot access local variable 'cmdargs' where it is not associated with a value
```
#### Fix
On Windows machines, ensure `cmdargs` is defined using the contents of the `recipes` arg

### Bug 2
#### Steps to Reproduce
On Windows, this line `[:platform_system == "Windows" or platform_system == "Darwin"]`
results in the following error when installing requirements unless the line is removed or rewritten:
```
>python -m pip install -r requirements.txt

ERROR: Invalid requirement: '[:platform_system == "Windows" or platform_system == "Darwin"]': Expected package name at the start of dependency specifier
    [:platform_system == "Windows" or platform_system == "Darwin"]
    ^ (from line 4 of requirements.txt)
```

If `requests` is not declared in `requirements.txt`, `python launcher` returns the following error:
```
>python launcher
Info: frozen=False meipass=False launcher=True
Traceback (most recent call last):
  File "FFcuesplitter-GUI\ffcuesplitter_gui\gui_app.py", line 108, in OnInit
    from ffcuesplitter_gui._main.main_frame import MainFrame
  File "FFcuesplitter-GUI\ffcuesplitter_gui\_main\main_frame.py", line 40, in <module>
    from ffcuesplitter_gui._io import io_tools
  File "FFcuesplitter-GUI\ffcuesplitter_gui\_io\io_tools.py", line 27, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
OnInit returned false, exiting...
```
#### Fix
- Require `requests` for Windows (and Darwin)
- Declare the conditionals using in-line semicolons